### PR TITLE
ClientWrapper as ContextClient

### DIFF
--- a/MacTcode.xcodeproj/project.pbxproj
+++ b/MacTcode.xcodeproj/project.pbxproj
@@ -718,7 +718,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 0.14.0;
+				MARKETING_VERSION = 0.14.1;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.mad-p.inputmethod.MacTcode";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -755,7 +755,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 0.14.0;
+				MARKETING_VERSION = 0.14.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.mad-p.inputmethod.MacTcode";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/MacTcode/Bushu/Bushu.swift
+++ b/MacTcode/Bushu/Bushu.swift
@@ -248,9 +248,8 @@ final class Bushu {
             return false
         }
 
-        guard let recent = client.recent else {
-            return false
-        }
+        let recent = client.recent
+        
         // 最後の2文字を取得できない場合は何もしない
         guard recent.text.count >= 2 else {
             return false

--- a/MacTcode/Client/ClientWrapper.swift
+++ b/MacTcode/Client/ClientWrapper.swift
@@ -8,33 +8,34 @@
 import Cocoa
 import InputMethodKit
 
-/// IMKTextInputをMyInputTextに見せかけるラッパー
-class ClientWrapper: Client {
-    let client: IMKTextInput
-    let _bundleId: String!
+/// IMKTextInputをContextClientに見せかけるラッパー
+class ClientWrapper: ContextClient {
+    private let inputText: IMKTextInput
+    private let _bundleId: String!
     init(_ client: IMKTextInput!, _ bundleId: String!) {
-        self.client = client
+        self.inputText = client
         self._bundleId = bundleId!
+        super.init(client: RecentTextClient(""), recent: RecentTextClient("")) // dummy
     }
-    func bundleId() -> String! {
+    override func bundleId() -> String! {
         return _bundleId
     }
-    func selectedRange() -> NSRange {
-        return client.selectedRange()
+    override func selectedRange() -> NSRange {
+        return inputText.selectedRange()
     }
-    func string(
+    override func string(
         from range: NSRange,
         actualRange: NSRangePointer
     ) -> String! {
-        return client.string(from: range, actualRange: actualRange)
+        return inputText.string(from: range, actualRange: actualRange)
     }
-    func insertText(
+    override func insertText(
         _ string: String,
         replacementRange rr: NSRange
     ) {
-        client.insertText(string, replacementRange: rr)
+        inputText.insertText(string, replacementRange: rr)
     }
-    func sendBackspace() {
+    override func sendBackspace() {
         let keyCode: CGKeyCode = 0x33
         let backspaceDown = CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: true)
         let backspaceUp = CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: false)

--- a/MacTcode/Tcode/TcodeInputController.swift
+++ b/MacTcode/Tcode/TcodeInputController.swift
@@ -72,7 +72,7 @@ class TcodeInputController: IMKInputController, Controller {
     func wrapClient() -> ContextClient {
         let textInput = self.client()!
         let bid = textInput.bundleIdentifier()
-        var wrappedClient = ContextClient(client: ClientWrapper(textInput, bid), recent: nil)
+        var wrappedClient: ContextClient = ClientWrapper(textInput, bid)
         // モードごとにclientに機能を追加する
         for m in modeStack.reversed() {
             wrappedClient = m.wrapClient(wrappedClient)

--- a/MacTcode/Tcode/TcodeMode.swift
+++ b/MacTcode/Tcode/TcodeMode.swift
@@ -18,13 +18,7 @@ class TcodeMode: Mode, MultiStroke {
         self.controller = controller
     }
     func wrapClient(_ client: ContextClient!) -> ContextClient! {
-        // TcodeModeが通常いちばん深いモード
-        if client.recent == nil {
-            // Log.i("TcodeMode: unwrap deepmost ContextClient")
-            return ContextClient(client: client.client, recent: recentText)
-        } else {
-            return ContextClient(client: client, recent: recentText)
-        }
+        return ContextClient(client: client, recent: recentText)
     }
     func resetPending() {
         pending = []


### PR DESCRIPTION
ClientWrapperをContextClientのサブクラスにすれば、TcodeModeでの特別扱いをしなくてよくなるし、
ContextClient.recentをオプショナル型にする必要はなくなる
