### PR TITLE
with imagemagick-full@7.1.2-23

### DIFF
--- a/scripts/Gemfile
+++ b/scripts/Gemfile
@@ -1,4 +1,4 @@
-ruby '3.3.0'
+ruby '4.0.4'
 
 source 'https://rubygems.org'
 

--- a/scripts/Gemfile.lock
+++ b/scripts/Gemfile.lock
@@ -1,9 +1,9 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    bigdecimal (4.0.1)
+    bigdecimal (4.1.2)
     chunky_png (1.4.0)
-    gruff (0.29.0)
+    gruff (0.32.0)
       bigdecimal (>= 3.0)
       histogram
       rmagick (>= 5.5)
@@ -13,7 +13,7 @@ GEM
       logger
     observer (0.1.2)
     pkg-config (1.6.5)
-    rmagick (6.2.0)
+    rmagick (7.0.0)
       observer (~> 0.1)
       pkg-config (~> 1.4)
 
@@ -27,18 +27,18 @@ DEPENDENCIES
   mini_magick
 
 CHECKSUMS
-  bigdecimal (4.0.1) sha256=8b07d3d065a9f921c80ceaea7c9d4ae596697295b584c296fe599dd0ad01c4a7
+  bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   chunky_png (1.4.0) sha256=89d5b31b55c0cf4da3cf89a2b4ebc3178d8abe8cbaf116a1dba95668502fdcfe
-  gruff (0.29.0) sha256=ab808cbf507abda7ffacd4ba5805a43c47ad0ec6aa2a7b125cf8a165110047a0
+  gruff (0.32.0) sha256=7bf4cbdae98108181c0fefe7d13a337dc48abc577a7ff42813bdb468cf6ca630
   histogram (0.2.4.1) sha256=9a6e379172b88ea842ab71700a535dd037185a4e17abcce742c7444679ae2abc
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   mini_magick (5.3.1) sha256=29395dfd76badcabb6403ee5aff6f681e867074f8f28ce08d78661e9e4a351c4
   observer (0.1.2) sha256=d8a3107131ba661138d748e7be3dbafc0d82e732fffba9fccb3d7829880950ac
   pkg-config (1.6.5) sha256=33f9f81c5322983d22b439b8b672f27777b406fea23bfec74ff14bbeb42ec733
-  rmagick (6.2.0) sha256=792791ccf513d84c48bac44ae12fa6988e25d27387f95bbf4dd44dcc8486569f
+  rmagick (7.0.0) sha256=18a4450b0ec6076bbad645e2180f18a8551d297c893f545cb886fd6fb3fde0b7
 
 RUBY VERSION
-  ruby 3.3.0
+  ruby 4.0.4
 
 BUNDLED WITH
   4.0.7


### PR DESCRIPTION
brew upgrade imagemagickしたところ、日本語フォントが読めなかったので、imagemagick-fullに更新。
Gemfile中のmini_magickをあわせて更新。