### PR TITLE
交ぜ書きの候補選択ガイドを確定時に正しく外す

### DIFF
--- a/MacTcode.xcodeproj/project.pbxproj
+++ b/MacTcode.xcodeproj/project.pbxproj
@@ -746,7 +746,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 0.20.0;
+				MARKETING_VERSION = 0.20.1;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.mad-p.inputmethod.MacTcode";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -783,7 +783,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 0.20.0;
+				MARKETING_VERSION = 0.20.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.mad-p.inputmethod.MacTcode";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/MacTcode/Mazegaki/MazegakiSelectionActions.swift
+++ b/MacTcode/Mazegaki/MazegakiSelectionActions.swift
@@ -30,7 +30,12 @@ class MazegakiSelectionCancelAction: MazegakiAction {
 class MazegakiSelectionKakuteiAction: MazegakiAction {
     override func action(client: any Client, mode: MazegakiSelectionMode, controller: any Controller) -> Command {
         Log.i("KakuteiAction")
-        _ = mode.mazegaki.submit(hit: mode.hits[mode.row], string: mode.candidateString, client: client, controller: controller)
+        let cand2 = mode.candidateString.replacingOccurrences(
+            of: #"^\d:"#,
+            with: "",
+            options: .regularExpression
+        )
+        _ = mode.mazegaki.submit(hit: mode.hits[mode.row], string: cand2, client: client, controller: controller)
         mode.cancel()
         return .processed
     }


### PR DESCRIPTION
fix #53 