### PR TITLE
かな/英数キーのイベントを無視する

### DIFF
--- a/MacTcode.xcodeproj/project.pbxproj
+++ b/MacTcode.xcodeproj/project.pbxproj
@@ -908,7 +908,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 0.21.0;
+				MARKETING_VERSION = 0.21.1;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.mad-p.inputmethod.MacTcode";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -945,7 +945,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 0.21.0;
+				MARKETING_VERSION = 0.21.1;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.mad-p.inputmethod.MacTcode";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/MacTcode/Keymap/InputEvent.swift
+++ b/MacTcode/Keymap/InputEvent.swift
@@ -29,6 +29,8 @@ enum InputEventType {
     case control_g
     /// それ以外
     case unknown
+    ///  日本語キーボードのイベント
+    case japanese
 }
 
 /// 入力イベント

--- a/MacTcode/Keymap/Translator.swift
+++ b/MacTcode/Keymap/Translator.swift
@@ -10,6 +10,8 @@ import InputMethodKit
 
 /// NSEventをInputEventに変換する
 class Translator {
+    static let JAPANESE_KEYS = [kVK_JIS_Eisu, kVK_JIS_Kana]
+
     static var layout: [String] {
         return UserConfigs.i.system.keyboardLayoutMapping
     }
@@ -49,7 +51,10 @@ class Translator {
         Log.i(" modifierFlags: \(flags)")
         
         var type: InputEventType = .unknown
-        if event.modifierFlags.contains(.option)
+        // かな、英数キーはここに来るまでに処理されているはずなので無視する
+        if Translator.JAPANESE_KEYS.contains(Int(event.keyCode)) {
+            type = .japanese
+        } else if event.modifierFlags.contains(.option)
             || event.modifierFlags.contains(.command)
         {
             type = .unknown

--- a/MacTcode/Mazegaki/MazegakiSelectionMode.swift
+++ b/MacTcode/Mazegaki/MazegakiSelectionMode.swift
@@ -79,7 +79,7 @@ class MazegakiSelectionMode: Mode, ModeWithCandidates {
         case .delete, .escape, .control_g:
             cancel()
             return .processed
-        case .control_punct, .unknown:
+        case .control_punct, .unknown, .japanese:
             return .processed
         }
     }

--- a/MacTcode/Tcode/TcodeKeymap.swift
+++ b/MacTcode/Tcode/TcodeKeymap.swift
@@ -36,6 +36,8 @@ fileprivate func buildTcodeKeymap() -> Keymap {
     if directMode != "" {
         KeymapResolver.define(sequence: directMode, keymap: map, action: DirectModeAction())
     }
+    // かな、英数キーはここに来るまでに処理されているはずなので無視する
+    map.replace(input: InputEvent(type: .japanese, text: " "), entry: .processed)
     // passthrough Ctrl-SPC (set-mark)
     map.replace(input: InputEvent(type: .control_punct, text: " "), entry: .passthrough)
     


### PR DESCRIPTION
JISキーボードのかな/英数キーで入力モードを切りかえた後、アプリ経由でそれらのキーのイベントが来ることがある。
モード切りかえは完了しているので、無視する。