### PR TITLE
年号入力を実装

### DIFF
--- a/MacTcode.xcodeproj/project.pbxproj
+++ b/MacTcode.xcodeproj/project.pbxproj
@@ -908,7 +908,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 0.21.2;
+				MARKETING_VERSION = 0.22.0;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.mad-p.inputmethod.MacTcode";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -945,7 +945,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 11.0;
-				MARKETING_VERSION = 0.21.2;
+				MARKETING_VERSION = 0.22.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "jp.mad-p.inputmethod.MacTcode";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/MacTcode/Tcode/TcodeKeymap.swift
+++ b/MacTcode/Tcode/TcodeKeymap.swift
@@ -36,6 +36,11 @@ fileprivate func buildTcodeKeymap() -> Keymap {
     if directMode != "" {
         KeymapResolver.define(sequence: directMode, keymap: map, action: DirectModeAction())
     }
+    
+    // 年号入力。直接入力に変更しつつ、元のキーを入力
+    KeymapResolver.define(sequence: "19", keymap: map, action: SelfInsertAndDirectMode(text: "19"))
+    KeymapResolver.define(sequence: "20", keymap: map, action: SelfInsertAndDirectMode(text: "20"))
+    
     // かな、英数キーはここに来るまでに処理されているはずなので無視する
     map.replace(input: InputEvent(type: .japanese, text: " "), entry: .processed)
     // passthrough Ctrl-SPC (set-mark)

--- a/MacTcode/Tcode/TcodeMode.swift
+++ b/MacTcode/Tcode/TcodeMode.swift
@@ -122,3 +122,16 @@ class DirectModeAction: Action {
         return .processed
     }
 }
+
+class SelfInsertAndDirectMode: Action {
+    var text: String
+    init(text: String) {
+        self.text = text
+    }
+    func execute(client: any Client, mode: any Mode, controller: any Controller) -> Command {
+        if let controller = controller as? TcodeInputController {
+            controller.setInputMode(.direct)
+        }
+        return .text(text)
+    }
+}


### PR DESCRIPTION
fixes #57 

* `19` および `20` で直接入力モードに切り換えつつ、その2文字自体を入力
